### PR TITLE
Add BMP, TIFF, WebP image format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A terminal image viewer with zoom and pan support, powered by the [Kitty Graphic
 - **High-performance rendering** - Image is uploaded once; zoom/pan updates only change the display region (~2.5ms/frame)
 - **Keyboard & mouse controls** - Vim-style keys, arrow keys, mouse drag-to-pan, scroll-to-zoom
 - **Configurable keybindings** - Customize all key mappings via TOML config file
-- **Multiple image formats** - PNG, JPEG, GIF
+- **Multiple image formats** - PNG, JPEG, GIF, BMP, TIFF, WebP
 - **Clean Architecture** - Modular design for easy extension and testing
 
 ## Supported Terminals
@@ -46,6 +46,7 @@ gaze <image-file>
 gaze photo.png
 gaze screenshot.jpg
 gaze animation.gif
+gaze image.webp
 ```
 
 ## Controls
@@ -114,7 +115,7 @@ internal/
     config/        TOML configuration loader
     renderer/      Kitty Graphics Protocol implementation
   infrastructure/
-    filesystem/    Image file loading (PNG, JPEG, GIF)
+    filesystem/    Image file loading (PNG, JPEG, GIF, BMP, TIFF, WebP)
 ```
 
 ## Development

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/image v0.36.0
 )
 
 require (
@@ -32,5 +33,5 @@ require (
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sys v0.38.0 // indirect
-	golang.org/x/text v0.3.8 // indirect
+	golang.org/x/text v0.34.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -53,10 +53,12 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJu
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
+golang.org/x/image v0.36.0 h1:Iknbfm1afbgtwPTmHnS2gTM/6PPZfH+z2EFuOkSbqwc=
+golang.org/x/image v0.36.0/go.mod h1:YsWD2TyyGKiIX1kZlu9QfKIsQ4nAAK9bdgdrIsE7xy4=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
 golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
-golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
-golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
+golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=
+golang.org/x/text v0.34.0/go.mod h1:homfLqTYRFyVYemLBFl5GgL/DWEiH5wcsQ5gSh1yziA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/infrastructure/filesystem/image_loader.go
+++ b/internal/infrastructure/filesystem/image_loader.go
@@ -8,6 +8,10 @@ import (
 	_ "image/png"
 	"os"
 
+	_ "golang.org/x/image/bmp"
+	_ "golang.org/x/image/tiff"
+	_ "golang.org/x/image/webp"
+
 	"github.com/flexphere/gaze/internal/domain"
 )
 
@@ -20,6 +24,7 @@ func NewImageLoader() *ImageLoader {
 }
 
 // Load reads and decodes an image file.
+// Supports PNG, JPEG, GIF, BMP, TIFF, WebP via image.Decode.
 func (l *ImageLoader) Load(path string) (*domain.ImageEntity, error) {
 	f, err := os.Open(path) //nolint:gosec // path is user-provided CLI argument
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add BMP, TIFF, WebP support via `golang.org/x/image` decoder registration (blank imports)
- No new code paths needed — formats are decoded through Go's standard `image.Decode()`
- Update README to reflect newly supported formats

## Test plan
- [x] `make ci` (lint + test + build) passes
- [ ] Manual test: `gaze <file.bmp>` renders correctly
- [ ] Manual test: `gaze <file.webp>` renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)