### PR TITLE
推奨linter4種を追加（errorlint, gocritic, unconvert, nilerr）

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,12 +12,16 @@ formatters:
 linters:
   enable:
     - errcheck
+    - errorlint
+    - gocritic
     - gosec
-    - staticcheck
     - govet
     - ineffassign
-    - unused
     - misspell
+    - nilerr
+    - staticcheck
+    - unconvert
+    - unused
   settings:
     errcheck:
       check-type-assertions: true


### PR DESCRIPTION
## 概要

golangci-lint に以下の4つの推奨linterを追加し、コード品質チェックを強化する。

## 変更内容

- `errorlint`: `%w`ラップや`errors.Is`/`errors.As`の誤用を検出
- `gocritic`: バグ・パフォーマンス・スタイルの総合チェック（auto-fix対応）
- `unconvert`: 不要な型変換の検出
- `nilerr`: `err != nil`チェック後にnilを返すバグの検出

既存コードに対する指摘は0件であり、コード変更は不要。
linterリストをアルファベット順に整理。

## テスト計画

- [x] `make ci` が全てパスすることを確認（lint / test / build）
- [x] 新規linterによる既存コードへの指摘が0件であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)